### PR TITLE
Fix incorrect shebang

### DIFF
--- a/add
+++ b/add
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # create the date string
 d=`date +%Y-%m-%d`


### PR DESCRIPTION
Use of the sh shebang will mean it invokes different command shells on different machines, and the script uses the {@:2}  array slicing operator which is not part of all shells. 
Also makes it more consistent with main todo.sh file which explicitly uses bash