### PR TITLE
Fix comments being interpreted

### DIFF
--- a/add
+++ b/add
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-% Add reformat the input arguments to remove the 'add' thats the "${@:2}"
-% Call todo.sh using the -t flag to add the created on date and the default add command.
+# Add reformat the input arguments to remove the 'add' thats the "${@:2}"
+# Call todo.sh using the -t flag to add the created on date and the default add command.
 todo.sh -t command add "${@:2}"
 


### PR DESCRIPTION
I guess these are some comments that were commented out with the wrong character, giving some unwanted output whenever a task is added. (Functionality is otherwise unaffected.)

Extra output looked like this:

/Users/harry/.todo.actions.d/add/add: line 3: fg: no job control
/Users/harry/.todo.actions.d/add/add: line 4: fg: no job control